### PR TITLE
feat: add PDF and image upload to chat

### DIFF
--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { ChangeEvent, FormEvent, KeyboardEvent } from "react";
-import { Send } from "lucide-react";
+import { ChangeEvent, FormEvent, KeyboardEvent, useRef, useState } from "react";
+import { Send, Paperclip, X, FileText } from "lucide-react";
+
+interface Attachment {
+  name: string;
+  contentType: string;
+  url: string;
+}
 
 interface MessageInputProps {
   input: string;
   handleInputChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
-  handleSubmit: (e: FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (
+    e: FormEvent<HTMLFormElement>,
+    options?: { experimental_attachments?: Attachment[] }
+  ) => void;
   isLoading: boolean;
 }
 
@@ -16,6 +25,9 @@ export function MessageInput({
   handleSubmit,
   isLoading,
 }: MessageInputProps) {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -26,25 +38,114 @@ export function MessageInput({
     }
   };
 
+  const readFileAsDataURL = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+      reader.readAsDataURL(file);
+    });
+
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    const newAttachments: Attachment[] = await Promise.all(
+      files.map(async (file) => ({
+        name: file.name,
+        contentType: file.type,
+        url: await readFileAsDataURL(file),
+      }))
+    );
+    setAttachments((prev) => [...prev, ...newAttachments]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const removeAttachment = (index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    handleSubmit(
+      e,
+      attachments.length > 0 ? { experimental_attachments: attachments } : undefined
+    );
+    setAttachments([]);
+  };
+
+  const canSubmit = input.trim() || attachments.length > 0;
+
   return (
-    <form onSubmit={handleSubmit} className="relative p-4 bg-white border-t border-neutral-200/60">
+    <form onSubmit={onSubmit} className="relative p-4 bg-white border-t border-neutral-200/60">
       <div className="relative max-w-4xl mx-auto">
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-2">
+            {attachments.map((attachment, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 bg-blue-50 rounded-lg border border-blue-100 text-sm"
+              >
+                {attachment.contentType.startsWith("image/") ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={attachment.url}
+                    alt={attachment.name}
+                    className="h-5 w-5 rounded object-cover flex-shrink-0"
+                  />
+                ) : (
+                  <FileText className="h-3.5 w-3.5 text-blue-600 flex-shrink-0" />
+                )}
+                <span className="text-neutral-700 max-w-[150px] truncate text-xs">
+                  {attachment.name}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => removeAttachment(i)}
+                  className="text-neutral-400 hover:text-neutral-600 ml-0.5"
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
         <textarea
           value={input}
           onChange={handleInputChange}
           onKeyDown={handleKeyDown}
-          placeholder="Describe the React component you want to create..."
+          placeholder="Describe the component you want, or upload a PDF/image..."
           disabled={isLoading}
-          className="w-full min-h-[80px] max-h-[200px] pl-4 pr-14 py-3.5 rounded-xl border border-neutral-200 bg-neutral-50/50 text-neutral-900 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500/10 focus:border-blue-500/50 focus:bg-white transition-all placeholder:text-neutral-400 text-[15px] font-normal shadow-sm"
+          className="w-full min-h-[80px] max-h-[200px] pl-4 pr-24 py-3.5 rounded-xl border border-neutral-200 bg-neutral-50/50 text-neutral-900 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500/10 focus:border-blue-500/50 focus:bg-white transition-all placeholder:text-neutral-400 text-[15px] font-normal shadow-sm"
           rows={3}
         />
-        <button 
-          type="submit" 
-          disabled={isLoading || !input.trim()}
-          className="absolute right-3 bottom-3 p-2.5 rounded-lg transition-all hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent group"
-        >
-          <Send className={`h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${isLoading || !input.trim() ? 'text-neutral-300' : 'text-blue-600'}`} />
-        </button>
+        <div className="absolute right-3 bottom-3 flex items-center gap-1">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*,application/pdf"
+            multiple
+            onChange={handleFileChange}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isLoading}
+            title="Upload PDF or image"
+            className="p-2.5 rounded-lg transition-all hover:bg-neutral-100 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            <Paperclip className="h-4 w-4 text-neutral-400 hover:text-neutral-600" />
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading || !canSubmit}
+            className="p-2.5 rounded-lg transition-all hover:bg-blue-50 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent group"
+          >
+            <Send
+              className={`h-4 w-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${
+                isLoading || !canSubmit ? "text-neutral-300" : "text-blue-600"
+              }`}
+            />
+          </button>
+        </div>
       </div>
     </form>
   );

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -2,7 +2,7 @@
 
 import { Message } from "ai";
 import { cn } from "@/lib/utils";
-import { User, Bot, Loader2 } from "lucide-react";
+import { User, Bot, Loader2, FileText } from "lucide-react";
 import { MarkdownRenderer } from "./MarkdownRenderer";
 
 const TOOL_DISPLAY_NAMES: Record<string, string> = {
@@ -51,10 +51,32 @@ export function MessageList({ messages, isLoading }: MessageListProps) {
               "flex flex-col gap-2 max-w-[85%]",
               message.role === "user" ? "items-end" : "items-start"
             )}>
+              {message.role === "user" && message.experimental_attachments && message.experimental_attachments.length > 0 && (
+                <div className="flex flex-wrap gap-2 justify-end">
+                  {message.experimental_attachments.map((attachment, i) => (
+                    attachment.contentType?.startsWith("image/") ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={i}
+                        src={attachment.url}
+                        alt={attachment.name ?? "attachment"}
+                        className="max-h-48 max-w-xs rounded-lg border border-neutral-200 shadow-sm object-contain"
+                      />
+                    ) : (
+                      <div key={i} className="flex items-center gap-2 px-3 py-2 bg-blue-50 rounded-lg border border-blue-100 text-sm">
+                        <FileText className="h-4 w-4 text-blue-600 flex-shrink-0" />
+                        <span className="text-neutral-700 max-w-[200px] truncate text-xs">
+                          {attachment.name ?? "file"}
+                        </span>
+                      </div>
+                    )
+                  ))}
+                </div>
+              )}
               <div className={cn(
                 "rounded-xl px-4 py-3",
-                message.role === "user" 
-                  ? "bg-blue-600 text-white shadow-sm" 
+                message.role === "user"
+                  ? "bg-blue-600 text-white shadow-sm"
                   : "bg-white text-neutral-900 border border-neutral-200 shadow-sm"
               )}>
                 <div className="text-sm">

--- a/src/lib/contexts/chat-context.tsx
+++ b/src/lib/contexts/chat-context.tsx
@@ -16,11 +16,20 @@ interface ChatContextProps {
   initialMessages?: Message[];
 }
 
+interface Attachment {
+  name: string;
+  contentType: string;
+  url: string;
+}
+
 interface ChatContextType {
   messages: Message[];
   input: string;
   handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  handleSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+  handleSubmit: (
+    e: React.FormEvent<HTMLFormElement>,
+    options?: { experimental_attachments?: Attachment[] }
+  ) => void;
   status: string;
 }
 


### PR DESCRIPTION
Adds file upload support to the chat input. Users can now attach PDFs or images (e.g. a resume) and have Claude generate a webpage based on the content.

Closes #7

Generated with [Claude Code](https://claude.ai/code)